### PR TITLE
Fixed a .NET 4.8 compatibility issue

### DIFF
--- a/Catalog.lua
+++ b/Catalog.lua
@@ -248,8 +248,9 @@ function GetMmsId(webPage)
 
     if(iframes.Count > 0) then
         -- Loop through the list of iframes until we get an mms id
-        for i = 0, iframes.Count - 1 do
-            local iframe = iframes:get_Item(i);
+        local iframesEnumerator = iframes:GetEnumerator();
+        while iframesEnumerator:MoveNext() do
+            local iframe = iframesEnumerator.Current;
             local src = ExtractIFrameSrc(iframe);
 
             if(src ~= nil and src ~= "") then

--- a/Config.xml
+++ b/Config.xml
@@ -2,7 +2,7 @@
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>Alma Primo Catalog Search</Name>
   <Author>Atlas Systems</Author>
-  <Version>1.5.1</Version>
+  <Version>1.5.2</Version>
   <Active>True</Active>
   <Type>Addon</Type>
   <Description>Catalog Search and Import Addon that uses Alma as the catalog and Primo as the discovery layer</Description>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 **1.5.1 -** *Fix:* Bibliographic information import
 
+**1.5.2 -** *Fix:* .NET 4.8 compatibility issue
 
 ## Summary
 


### PR DESCRIPTION
A site reported an issue with the addon that started occurring after upgrading to .NET 4.8. The signature of the issue is in line with issues that other addons started experiencing after upgrading to .NET 4.8. Swapping the `get_Item` calls to using IEnumerable's `GetEnumerator`, `MoveNext`, and `Current` fixes the issue.